### PR TITLE
(SERVER-1604) Compress gatling simulation.log files

### DIFF
--- a/src/test/java/com/puppetlabs/jenkins/plugins/puppetgatling/steps/PuppetGatlingArchiverStepTest.java
+++ b/src/test/java/com/puppetlabs/jenkins/plugins/puppetgatling/steps/PuppetGatlingArchiverStepTest.java
@@ -50,6 +50,15 @@ public class PuppetGatlingArchiverStepTest extends Assert {
                 1, buildActions.size());
         PuppetGatlingBuildAction pgba = buildActions.get(0);
 
+        String simDir = "simulations/my-sim-1470844250439";
+        File origSimulationLog = new File(b.getRootDir(), simDir + "/simulation.log");
+        File compressedSimulationLog = new File(b.getRootDir(), simDir + "/simulation.log.gz");
+
+        assertFalse("Original simulation log file '" + origSimulationLog + "' should not exist",
+                origSimulationLog.exists());
+        assertTrue("Compressed simulation log file '" + origSimulationLog + "' should exist",
+                compressedSimulationLog.exists());
+
         assertEquals("/plugin/puppet-gatling-jenkins-plugin/img/puppet.png", pgba.getIconFileName());
         assertEquals("Puppet Gatling", pgba.getDisplayName());
         assertEquals("puppet-gatling", pgba.getUrlName());

--- a/src/test/java/com/puppetlabs/jenkins/plugins/puppetgatling/steps/PuppetGatlingArchiverStepTest.java
+++ b/src/test/java/com/puppetlabs/jenkins/plugins/puppetgatling/steps/PuppetGatlingArchiverStepTest.java
@@ -56,7 +56,7 @@ public class PuppetGatlingArchiverStepTest extends Assert {
 
         assertFalse("Original simulation log file '" + origSimulationLog + "' should not exist",
                 origSimulationLog.exists());
-        assertTrue("Compressed simulation log file '" + origSimulationLog + "' should exist",
+        assertTrue("Compressed simulation log file '" + compressedSimulationLog + "' should exist",
                 compressedSimulationLog.exists());
 
         assertEquals("/plugin/puppet-gatling-jenkins-plugin/img/puppet.png", pgba.getIconFileName());


### PR DESCRIPTION
This commit adds some logic to the step where we are archiving the
gatling report directory, to gzip the `simulation.log` file before
archiving it.  This will allow us to retain more build history
on the jenkins server, since these files can be very large.